### PR TITLE
Ensure compatibility with NixOS

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,16 +16,16 @@ install:
     just build
     mkdir -p ~/.local/share/avalonia-ls
     cp bin/* ~/.local/share/avalonia-ls -r
-    echo -e "#!/bin/bash\n exec ~/.local/share/avalonia-ls/xaml-styler/xstyler \"\$@\"" > ~/.local/bin/xaml-styler
+    echo -e "#!/usr/bin/env bash\n exec ~/.local/share/avalonia-ls/xaml-styler/xstyler \"\$@\"" > ~/.local/bin/xaml-styler
     chmod +x ~/.local/bin/xaml-styler
     
-    echo -e "#!/bin/bash\n exec ~/.local/share/avalonia-ls/lsp/AvaloniaLanguageServer \"\$@\"" > ~/.local/bin/avalonia-ls
+    echo -e "#!/usr/bin/env bash\n exec ~/.local/share/avalonia-ls/lsp/AvaloniaLanguageServer \"\$@\"" > ~/.local/bin/avalonia-ls
     chmod +x ~/.local/bin/avalonia-ls
     
-    echo -e "#!/bin/bash\n exec ~/.local/share/avalonia-ls/solution-parser/SolutionParser \"\$@\"" > ~/.local/bin/avalonia-solution-parser
+    echo -e "#!/usr/bin/env bash\n exec ~/.local/share/avalonia-ls/solution-parser/SolutionParser \"\$@\"" > ~/.local/bin/avalonia-solution-parser
     chmod +x ~/.local/bin/avalonia-solution-parser
 
-    echo -e "#/!bin/bash\n exec ~/.local/share/avalonia-ls/avalonia-preview/AvaloniaPreview \"\$@\"" > ~/.local/bin/avalonia-preview
+    echo -e "#!/usr/bin/env bash\n exec ~/.local/share/avalonia-ls/avalonia-preview/AvaloniaPreview \"\$@\"" > ~/.local/bin/avalonia-preview
     chmod +x ~/.local/bin/avalonia-preview
 
     @echo "INSTALLATION COMPLETE!"


### PR DESCRIPTION
This ensures compatibility with NixOS; the `env` command doesn't prevent functionality on other Linux systems but allows finding the correct path to `bash`.
